### PR TITLE
Add more information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Protocol Definition Files
+[Boom Beach] Protocol Definition Files
 =========================
 
-Clash messages are passed between client and server in PDUs containing an integer message identifier
+Messages are passed between client and server in PDUs containing an integer message identifier
 and a binary payload. The files in this package are used to map the identifier to a message
-structure definition so that the binary payload can be parsed.
+structure definition so that the binary payload can be parsed. This is used in every Supercell game.
 
 Each message structure is defined in an individual JSON file. The name of the file is not
 significant, but generally it corresponds to the type name of the message.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [Boom Beach] Protocol Definition Files
 =========================
 
-Through Supercell games' protocols, are messages that are passed between the client and server, in PDUs containing an integer message identifier and a binary patload. The files in this package are used to map the identifier to a message structure definition so that the binary payload can be parsed. 
+Through Supercell games' protocols, are messages that are passed between the client and server, in PDUs containing an integer message identifier and a binary payload. The files in this package are used to map the identifier to a message structure definition so that the binary payload can be parsed. 
 
 The files have message structures, which are formatted in JSON for wide-range compatibility with other languages and allows for simple implementation of parsers. Each file is generally assigned a name for the data that the message carries.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 [Boom Beach] Protocol Definition Files
 =========================
 
-Messages are passed between client and server in PDUs containing an integer message identifier
-and a binary payload. The files in this package are used to map the identifier to a message
-structure definition so that the binary payload can be parsed. This is used in every Supercell game.
+Through Supercell games' protocols, are messages that are passed between the client and server, in PDUs containing an integer message identifier and a binary patload. The files in this package are used to map the identifier to a message structure definition so that the binary payload can be parsed. 
 
-Each message structure is defined in an individual JSON file. The name of the file is not
-significant, but generally it corresponds to the type name of the message.
+The files have message structures, which are formatted in JSON for wide-range compatibility with other languages and allows for simple implementation of parsers. Each file is generally assigned a name for the data that the message carries.
 
 Type System
 ===========

--- a/README.md
+++ b/README.md
@@ -136,3 +136,14 @@ Comments
 --------
 
 Messages and Fields may have a *comment* attribute to document their use.
+
+Unnamed Type Fields
+--------
+
+Fields that are assigned a type (without name or comment), for example:
+
+```
+{"type":"BYTE"}
+```
+
+are possibly unknown or unused.


### PR DESCRIPTION
Update the README to state that the PDUs are used in every Supercell game, also explaining why the package files are in JSON format. Also added a bit of information about unnamed type fields.